### PR TITLE
ManiaModUpdater now removes Devkitpro from the path before it runs find

### DIFF
--- a/ManiaModUpdater.bat
+++ b/ManiaModUpdater.bat
@@ -4,6 +4,10 @@ set color=color
 set not_support=not_support
 set updater=updater
 
+::Backs up and Removes DevkitPro from PATH
+set oldPATH=%PATH%
+path %oldPATH:c:\devkitPro\msys\bin;=% >nul
+
 setLocal EnableDelayedExpansion
 find /i "IsEnableColours=false" ManiaModUpdater.config
 if %errorlevel% EQU 0 (set color=no)
@@ -447,3 +451,6 @@ goto begin
 
 :end
 
+:: Restores PATH
+:: NOTE: This doesn't seem to work after the script ends
+path %oldPATH%


### PR DESCRIPTION
This should hopefully stop the script from listing all the files in I:\ 

 ## 8e2d064
I have made this because people including me who have DevkitPro may have
troubles running this script since DevkitPro commands by default have
higher priority over system32. This commit should make the script remove
DevkitPro from the path if its installed in its default location.